### PR TITLE
fix: Use cwd to call publish instead of passing the path

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,4 @@
-import { info } from '@actions/core';
+import { info, warning } from '@actions/core';
 import { GithubConfig, ProjectConfig, ProjectFlavor } from './config';
 import { context, getOctokit } from '@actions/github';
 
@@ -49,7 +49,9 @@ async function getChangedFiles(config: GithubConfig): Promise<string[]> {
 	}
 
 	if (compareResponse.data.status !== 'ahead') {
-		throw new Error(`The head commit for this ${context.eventName} event is not ahead of the base commit.`);
+		warning(`The head commit for this ${context.eventName} event is not ahead of the base commit.`);
+		warning('Skipping the changed file check.');
+		return [];
 	}
 
 	return (compareResponse.data.files || []).map(file => file.filename);

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -14,7 +14,9 @@ export function findManifestUrl(text: string): string {
 
 export async function publish(config: PublishConfig): Promise<string> {
 	const { exitCode, stderr, stdout } = await getExecOutput(
-		`${config.cliPath} publish ${config.projectRoot || ''} --release-channel=${config.channel}`
+		`${config.cliPath} publish --release-channel=${config.channel}`,
+		undefined,
+		{ cwd: config.projectRoot },
 	);
 	if (exitCode !== 0) {
 		throw new Error(stderr);


### PR DESCRIPTION
Calling publish with a directory seems to be problematic. Given a setup with `projectRoot: mobile/`, I witnessed the following issues:
* Babel seemed to use `.babelrc.js` instead of the `mobile/babel.config.js`.
* Metro ignored the config file `mobile/metro.config.js`.

Given these issues, I think it might just make sense to change the `cwd` when calling publish — it is a relatively localized change.