### PR TITLE
Adds Project page variable in action output

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
 	"printWidth": 120,
   "tabWidth": 2,
+  "useTabs": false,
 	"singleQuote": true,
 	"jsxBracketSameLine": true,
 	"trailingComma": "es5",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This action will publish your project (to your configured `channel`) using `expo
 - `EXPO_NEW_BUILD_IS_REQUIRED` - Whether a new build of your application is required to open generated preview.
 - `EXPO_NEW_BUILD_IS_REQUIRED_MESSAGE` - If a new build of your application is required to open generated preview, it will contain a default warning message.
 
-You can use those variables to do whatever you want. For example, you can chain this action with [unsplash/comment-on-pr](https://github.com/unsplash/comment-on-pr) to add a comment with QR code under pull request. See [example workflows below](#-example-workflows)
+You can use those variables to do whatever you want. For example, you can chain this action with [unsplash/comment-on-pr](https://github.com/unsplash/comment-on-pr) to add a comment with QR code under pull request. See [example workflows below](#-example-workflows).
 
 ## ⚙️ Configuration options
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>expo preview action</h1>
   <p></p>
-  <p>Create a fast preview under each pull request to test changes in your <a href="https://github.com/expo/expo">Expo</a> app with Github Actions!</p>
+  <p>This action allows you to automate expo build previews on pull requests to test your <a href="https://github.com/expo/expo">Expo</a> app builds!</p>
   <sup>
     <a href="https://github.com/expo/expo-preview-action/releases">
       <img src="https://img.shields.io/github/release/expo/expo-preview-action/all.svg?style=flat-square" alt="releases" />
@@ -38,14 +38,15 @@ This action requires `expo-cli` to be set up in your action environment. You can
 
 ## 🏃‍♂️ How it works
 
-After adding this action to your workflow, it will publish your project using `expo-cli` and produce as an output two variables:
+This action will publish your project (to your configured `channel`) using `expo-cli` and produce output with the following variables:
 
 - `EXPO_MANIFEST_URL` - A URL pointing to the expo manifest of the published version.
 - `EXPO_QR_CODE_URL` - A URL pointing to the generated QR code which can be scanned using Expo Go or custom development client.
+- `EXPO_PROJECT_URL` - URL pointing to the expo project page with customizable QR code and deep link. This page lets you get the code/url for varying clients (expo go, or your expo development build). More on project pages [here](https://github.com/expo/fyi/blob/main/project-page.md).
 - `EXPO_NEW_BUILD_IS_REQUIRED` - Whether a new build of your application is required to open generated preview.
 - `EXPO_NEW_BUILD_IS_REQUIRED_MESSAGE` - If a new build of your application is required to open generated preview, it will contain a default warning message.
 
-You can use those variables to do whatever you want. For example, you can chain this action with [unsplash/comment-on-pr](https://github.com/unsplash/comment-on-pr) to add a comment with QR code under pull request.
+You can use those variables to do whatever you want. For example, you can chain this action with [unsplash/comment-on-pr](https://github.com/unsplash/comment-on-pr) to add a comment with QR code under pull request. See [example workflows below](#-example-workflows)
 
 ## ⚙️ Configuration options
 
@@ -64,7 +65,7 @@ This action is customizable through variables - they are defined in the [action.
 ## 📝 Example workflows
 
 Before you dive into the workflow examples, you should know the basics of GitHub Actions.
-You can read more about this in the [GitHub Actions documentation][link-actions].
+You can read more about this in the [GitHub Actions documentation](https://docs.github.com/en/actions).
 
 - [📦 What's inside?](#-whats-inside)
 - [🔧 Set up](#-set-up)
@@ -114,8 +115,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           msg: >
-            Awesome! You can [preview the PR here](${{ steps.preview.outputs.EXPO_QR_CODE_URL }}).<br><br>
+            You can [preview the PR here](${{ steps.preview.outputs.EXPO_QR_CODE_URL }}).<br><br>
             <a href="${{ steps.publish.outputs.EXPO_QR_CODE_URL }}"><img src="${{ steps.preview.outputs.EXPO_QR_CODE_URL }}" height="512px" width="512px"></a>
+            <br><br>
+            QR code not working or need a different client? Try the QR code or deep link from the [project page](${{steps.preview.outputs.EXPO_PROJECT_URL}}).
             <br><br>
             ${{ steps.publish.outputs.EXPO_NEW_BUILD_IS_REQUIRED_MESSAGE }}
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With this preview action, you can test changes made in pull requests via Expo Go
 
 This action requires `expo-cli` to be set up in your action environment. You can do it by yourself, but we encourage you to use [expo-github-action](https://github.com/expo/expo-github-action) to make this process as easy as possible.
 
-> Note: You need to be login into `expo-cli`. [See (https://github.com/expo/expo-github-action#automatic-expo-login)].
+> Note: You need to be logged in to `expo-cli`  ([expo automatic login](https://github.com/expo/expo-github-action#automatic-expo-login)).
 
 > ⚠️ If you're using a custom development client, your native project needs to contain configured `expo-updates` to be able to open published applications.
 
@@ -53,21 +53,26 @@ This action is customizable through variables - they are defined in the [action.
 
 | variable                | required | description                                                                                                                                                                                                                            |
 | ----------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `channel`               | ✔️       | The name of the update channel where your application will be published. [Learn more](https://docs.expo.io/distribution/release-channels/).                                                                                            |
-| `project-flavor`        | ❌       | The type of the project. Available options: 'development-client' or 'expo-go'. Defaults to 'development-client'.                                                                                                                       |
-| `scheme`                | ❌       | The deep link scheme which will be used to open your project. This value isn't required, but we recommend setting it. Otherwise, action tries to guess the value. If you are using Expo Go to preview changes, this option is ignored. |
-| `project-root`          | ❌       | The path to the folder where package.json lives. Defaults to main directory of the repository.                                                                                                                                         |
-| `expo-cli-path`         | ❌       | The path to the `expo-cli`. If you're using the `expo-github-action` or `expo-cli` was installed in the `bin` folder, you should ignore this option.                                                                                   |
-| `android-manifest-path` | ❌       | The path to the `AndroidManifest.xml`. If `scheme` was provided or you're using the managed workflow, this option is ignored.                                                                                                          |
-| `ios-info-plist-path`   | ❌       | The path to the `Info.plist`. If `scheme` was provided or you're using the managed workflow, this option is ignored.                                                                                                                   |
+| `channel`               | ✔️        | The name of the update channel where your application will be published. [Learn more](https://docs.expo.io/distribution/release-channels/).                                                                                            |
+| `project-flavor`        | ❌        | The type of the project. Available options: 'development-client' or 'expo-go'. Defaults to 'development-client'.                                                                                                                       |
+| `scheme`                | ❌        | The deep link scheme which will be used to open your project. This value isn't required, but we recommend setting it. Otherwise, action tries to guess the value. If you are using Expo Go to preview changes, this option is ignored. |
+| `project-root`          | ❌        | The path to the folder where package.json lives. Defaults to main directory of the repository.                                                                                                                                         |
+| `expo-cli-path`         | ❌        | The path to the `expo-cli`. If you're using the `expo-github-action` or `expo-cli` was installed in the `bin` folder, you should ignore this option.                                                                                   |
+| `android-manifest-path` | ❌        | The path to the `AndroidManifest.xml`. If `scheme` was provided or you're using the managed workflow, this option is ignored.                                                                                                          |
+| `ios-info-plist-path`   | ❌        | The path to the `Info.plist`. If `scheme` was provided or you're using the managed workflow, this option is ignored.                                                                                                                   |
 
 ## 📝 Example workflows
 
 Before you dive into the workflow examples, you should know the basics of GitHub Actions.
 You can read more about this in the [GitHub Actions documentation][link-actions].
 
-- [Create a QR code under pull request](#create-a-qr-code-under-pull-request)
-- [Create a preview only if app files were changed](#create-a-preview-only-if-app-files-were-changed)
+- [📦 What's inside?](#-whats-inside)
+- [🔧 Set up](#-set-up)
+- [🏃‍♂️ How it works](#️-how-it-works)
+- [⚙️ Configuration options](#️-configuration-options)
+- [📝 Example workflows](#-example-workflows)
+  - [Create a QR code under pull request](#create-a-qr-code-under-pull-request)
+  - [Create a preview only if app files were changed](#create-a-preview-only-if-app-files-were-changed)
 
 ### Create a QR code under pull request
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Expo GitHub Action - Fork
+name: Expo GitHub Action
 author: Expo
 description: Expo CLI in your GitHub Actions workflow.
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Expo GitHub Action
+name: Expo GitHub Action - Fork
 author: Expo
 description: Expo CLI in your GitHub Actions workflow.
 branding:

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,6 +1,5 @@
-import { getExecOutput } from '@actions/exec';
-
-import { PublishConfig } from './config';
+import { getExecOutput } from "@actions/exec"
+import { PublishConfig } from "./config"
 
 export function findManifestUrl(text: string): string {
 	const regex = /📝 {2}Manifest: ([^ ]*)/;
@@ -12,15 +11,28 @@ export function findManifestUrl(text: string): string {
 	return match;
 }
 
-export async function publish(config: PublishConfig): Promise<string> {
+export function findProjectPage(text: string): string {
+	const regex = /⚙️ {3}Project page: ([^ ]*)/;
+
+	const match = (text.match(regex) || [])[1];
+	if (!match) {
+		throw new Error("Couldn't extract project page URL.");
+	}
+
+	return match;
+}
+
+export async function publish(config: PublishConfig): Promise<{ manifestURL: string; projectPageURL: string }> {
 	const { exitCode, stderr, stdout } = await getExecOutput(
 		`${config.cliPath} publish --release-channel=${config.channel}`,
 		undefined,
-		{ cwd: config.projectRoot },
+		{ cwd: config.projectRoot }
 	);
 	if (exitCode !== 0) {
 		throw new Error(stderr);
 	}
+	const manifestURL = findManifestUrl(stdout);
+	const projectPageURL = findProjectPage(stdout);
 
-	return findManifestUrl(stdout);
+	return { manifestURL, projectPageURL };
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -2,37 +2,37 @@ import { getExecOutput } from '@actions/exec';
 import { PublishConfig } from './config';
 
 export function findManifestUrl(text: string): string {
-	const regex = /📝 {2}Manifest: ([^ ]*)/;
-	const match = (text.match(regex) || [])[1];
-	if (!match) {
-		throw new Error("Couldn't extract manifest URL.");
-	}
+  const regex = /📝 {2}Manifest: ([^ ]*)/;
+  const match = (text.match(regex) || [])[1];
+  if (!match) {
+    throw new Error("Couldn't extract manifest URL.");
+  }
 
-	return match;
+  return match;
 }
 
 export function findProjectPage(text: string): string {
-	const regex = /⚙️ {3}Project page: ([^ ]*)/;
+  const regex = /⚙️ {3}Project page: ([^ ]*)/;
 
-	const match = (text.match(regex) || [])[1];
-	if (!match) {
-		throw new Error("Couldn't extract project page URL.");
-	}
+  const match = (text.match(regex) || [])[1];
+  if (!match) {
+    throw new Error("Couldn't extract project page URL.");
+  }
 
-	return match;
+  return match;
 }
 
 export async function publish(config: PublishConfig): Promise<{ manifestURL: string; projectPageURL: string }> {
-	const { exitCode, stderr, stdout } = await getExecOutput(
-		`${config.cliPath} publish --release-channel=${config.channel}`,
-		undefined,
-		{ cwd: config.projectRoot }
-	);
-	if (exitCode !== 0) {
-		throw new Error(stderr);
-	}
-	const manifestURL = findManifestUrl(stdout);
-	const projectPageURL = findProjectPage(stdout);
+  const { exitCode, stderr, stdout } = await getExecOutput(
+    `${config.cliPath} publish --release-channel=${config.channel}`,
+    undefined,
+    { cwd: config.projectRoot }
+  );
+  if (exitCode !== 0) {
+    throw new Error(stderr);
+  }
+  const manifestURL = findManifestUrl(stdout);
+  const projectPageURL = findProjectPage(stdout);
 
-	return { manifestURL, projectPageURL };
+  return { manifestURL, projectPageURL };
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,5 +1,5 @@
-import { getExecOutput } from "@actions/exec"
-import { PublishConfig } from "./config"
+import { getExecOutput } from '@actions/exec';
+import { PublishConfig } from './config';
 
 export function findManifestUrl(text: string): string {
 	const regex = /📝 {2}Manifest: ([^ ]*)/;

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,14 +1,9 @@
-import { chooseScheme } from "./scheme"
-import { Config, ProjectFlavor } from "./config"
-import { createQRCodeURL } from "./url"
-import {
-	getInput,
-	group,
-	info,
-	setOutput
-	} from "@actions/core"
-import { needNewDevClientBuild } from "./github"
-import { publish } from "./publish"
+import { Config, ProjectFlavor } from './config';
+import { group, getInput, setOutput, info } from '@actions/core';
+import { publish } from './publish';
+import { chooseScheme } from './scheme';
+import { createQRCodeURL } from './url';
+import { needNewDevClientBuild } from './github';
 
 function undefinedIfEmpty(string: string): string | undefined {
 	return string || undefined;

--- a/src/run.ts
+++ b/src/run.ts
@@ -6,61 +6,61 @@ import { createQRCodeURL } from './url';
 import { needNewDevClientBuild } from './github';
 
 function undefinedIfEmpty(string: string): string | undefined {
-	return string || undefined;
+  return string || undefined;
 }
 
 function parseProjectFlavor(flavor: string): ProjectFlavor | undefined {
-	if (flavor === 'expo-go') {
-		return ProjectFlavor.ExpoGo;
-	} else if (flavor === 'development-client') {
-		return ProjectFlavor.DevelopmentClient;
-	}
+  if (flavor === 'expo-go') {
+    return ProjectFlavor.ExpoGo;
+  } else if (flavor === 'development-client') {
+    return ProjectFlavor.DevelopmentClient;
+  }
 
-	if (flavor) {
-		throw new Error(`Invalid "project-flavor" value. available options: 'expo-go' or 'development-client'.`);
-	}
+  if (flavor) {
+    throw new Error(`Invalid "project-flavor" value. available options: 'expo-go' or 'development-client'.`);
+  }
 
-	return undefined;
+  return undefined;
 }
 
 export async function run(): Promise<void> {
-	const config: Config = {
-		projectFlavor: parseProjectFlavor(getInput('project-flavor')) || ProjectFlavor.DevelopmentClient,
-		channel: getInput('channel'),
-		cliPath: getInput('expo-cli-path') || 'expo',
-		scheme: undefinedIfEmpty(getInput('scheme')),
-		projectRoot: undefinedIfEmpty(getInput('project-root')),
-		manifestPath: undefinedIfEmpty(getInput('android-manifest-path')),
-		infoPlist: undefinedIfEmpty(getInput('ios-info-plist-path')),
-		token: getInput('token', { required: true }),
-	};
+  const config: Config = {
+    projectFlavor: parseProjectFlavor(getInput('project-flavor')) || ProjectFlavor.DevelopmentClient,
+    channel: getInput('channel'),
+    cliPath: getInput('expo-cli-path') || 'expo',
+    scheme: undefinedIfEmpty(getInput('scheme')),
+    projectRoot: undefinedIfEmpty(getInput('project-root')),
+    manifestPath: undefinedIfEmpty(getInput('android-manifest-path')),
+    infoPlist: undefinedIfEmpty(getInput('ios-info-plist-path')),
+    token: getInput('token', { required: true }),
+  };
 
-	const scheme = await group('Choose scheme', async () => {
-		const scheme = await chooseScheme(config);
-		info(`Chosen scheme: ${scheme}`);
-		return scheme;
-	});
+  const scheme = await group('Choose scheme', async () => {
+    const scheme = await chooseScheme(config);
+    info(`Chosen scheme: ${scheme}`);
+    return scheme;
+  });
 
-	const needToRebuildDevClient = await group('Check if a new version of the development client is required', () =>
-		needNewDevClientBuild(config)
-	);
+  const needToRebuildDevClient = await group('Check if a new version of the development client is required', () =>
+    needNewDevClientBuild(config)
+  );
 
-	const { manifestURL, projectPageURL } = await group('Publish application', () => publish(config));
+  const { manifestURL, projectPageURL } = await group('Publish application', () => publish(config));
 
-	const QRCodeURL = await group('Create QRCode', () => {
-		const qrCode = createQRCodeURL(config.projectFlavor, manifestURL, scheme);
-		info(`QR Code is available under: ${qrCode}`);
-		return Promise.resolve(qrCode);
-	});
+  const QRCodeURL = await group('Create QRCode', () => {
+    const qrCode = createQRCodeURL(config.projectFlavor, manifestURL, scheme);
+    info(`QR Code is available under: ${qrCode}`);
+    return Promise.resolve(qrCode);
+  });
 
-	setOutput('EXPO_MANIFEST_URL', manifestURL);
-	setOutput('EXPO_PROJECT_URL', projectPageURL);
-	setOutput('EXPO_QR_CODE_URL', QRCodeURL);
-	setOutput('EXPO_NEW_BUILD_IS_REQUIRED', needToRebuildDevClient);
-	setOutput(
-		'EXPO_NEW_BUILD_IS_REQUIRED_MESSAGE',
-		needToRebuildDevClient
-			? `<strong>⚠️ Warning</strong>: To open this preview, you may need to rebuild your native application.`
-			: ''
-	);
+  setOutput('EXPO_MANIFEST_URL', manifestURL);
+  setOutput('EXPO_PROJECT_URL', projectPageURL);
+  setOutput('EXPO_QR_CODE_URL', QRCodeURL);
+  setOutput('EXPO_NEW_BUILD_IS_REQUIRED', needToRebuildDevClient);
+  setOutput(
+    'EXPO_NEW_BUILD_IS_REQUIRED_MESSAGE',
+    needToRebuildDevClient
+      ? `<strong>⚠️ Warning</strong>: To open this preview, you may need to rebuild your native application.`
+      : ''
+  );
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,9 +1,14 @@
-import { Config, ProjectFlavor } from './config';
-import { group, getInput, setOutput, info } from '@actions/core';
-import { publish } from './publish';
-import { chooseScheme } from './scheme';
-import { createQRCodeURL } from './url';
-import { needNewDevClientBuild } from './github';
+import { chooseScheme } from "./scheme"
+import { Config, ProjectFlavor } from "./config"
+import { createQRCodeURL } from "./url"
+import {
+	getInput,
+	group,
+	info,
+	setOutput
+	} from "@actions/core"
+import { needNewDevClientBuild } from "./github"
+import { publish } from "./publish"
 
 function undefinedIfEmpty(string: string): string | undefined {
 	return string || undefined;
@@ -45,7 +50,7 @@ export async function run(): Promise<void> {
 		needNewDevClientBuild(config)
 	);
 
-	const manifestURL = await group('Publish application', () => publish(config));
+	const { manifestURL, projectPageURL } = await group('Publish application', () => publish(config));
 
 	const QRCodeURL = await group('Create QRCode', () => {
 		const qrCode = createQRCodeURL(config.projectFlavor, manifestURL, scheme);
@@ -54,6 +59,7 @@ export async function run(): Promise<void> {
 	});
 
 	setOutput('EXPO_MANIFEST_URL', manifestURL);
+	setOutput('EXPO_PROJECT_URL', projectPageURL);
 	setOutput('EXPO_QR_CODE_URL', QRCodeURL);
 	setOutput('EXPO_NEW_BUILD_IS_REQUIRED', needToRebuildDevClient);
 	setOutput(

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -1,8 +1,8 @@
 import { findManifestUrl, findProjectPage } from '../src/publish';
 
 describe('findProjectPageURL', () => {
-	it('should find project page URL', () => {
-		const expoPublishOutput = `
+  it('should find project page URL', () => {
+    const expoPublishOutput = `
 [15:22:15] › Expo SDK: 41.0.0
 [15:22:15] › Release channel: pr-3
 [15:22:15] › Workflow: Bare
@@ -33,20 +33,20 @@ Processing asset bundle patterns:
 [15:24:42] ⚙️   Project page: https://expo.dev/@markwas/here?release-channel=pr-3 Learn more: https://expo.fyi/project-page
 
 `;
-		const projectPageUrl = findProjectPage(expoPublishOutput);
-		expect(projectPageUrl).toBe('https://expo.dev/@markwas/here?release-channel=pr-3');
-	});
+    const projectPageUrl = findProjectPage(expoPublishOutput);
+    expect(projectPageUrl).toBe('https://expo.dev/@markwas/here?release-channel=pr-3');
+  });
 
-	it('should throw if cannot find project page URL', () => {
-		expect(() => {
-			const expoPublishOutput = 'nothing to see here...';
-			findManifestUrl(expoPublishOutput);
-		}).toThrow();
-	});
+  it('should throw if cannot find project page URL', () => {
+    expect(() => {
+      const expoPublishOutput = 'nothing to see here...';
+      findManifestUrl(expoPublishOutput);
+    }).toThrow();
+  });
 });
 describe('findManifestUrl', () => {
-	it('should find manifest URL', () => {
-		const expoPublishOutput = `
+  it('should find manifest URL', () => {
+    const expoPublishOutput = `
 [15:22:15] › Expo SDK: 41.0.0
 [15:22:15] › Release channel: pr-3
 [15:22:15] › Workflow: Bare
@@ -75,14 +75,14 @@ Processing asset bundle patterns:
 
 [15:24:41] 📝  Manifest: https://exp.host/@lukaszkosmaty/tabs/index.exp?release-channel=pr-3&sdkVersion=41.0.0 Learn more: expo.fyi/manifest-url
 `;
-		const manifestURL = findManifestUrl(expoPublishOutput);
+    const manifestURL = findManifestUrl(expoPublishOutput);
 
-		expect(manifestURL).toBe('https://exp.host/@lukaszkosmaty/tabs/index.exp?release-channel=pr-3&sdkVersion=41.0.0');
-	});
+    expect(manifestURL).toBe('https://exp.host/@lukaszkosmaty/tabs/index.exp?release-channel=pr-3&sdkVersion=41.0.0');
+  });
 
-	it('should throw if cannot find manifest URL', () => {
-		expect(() => {
-			findManifestUrl('Missing manifest URL');
-		}).toThrow();
-	});
+  it('should throw if cannot find manifest URL', () => {
+    expect(() => {
+      findManifestUrl('Missing manifest URL');
+    }).toThrow();
+  });
 });

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -1,4 +1,4 @@
-import { findManifestUrl, findProjectPage } from "../src/publish"
+import { findManifestUrl, findProjectPage } from '../src/publish';
 
 describe('findProjectPageURL', () => {
 	it('should find project page URL', () => {

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -1,5 +1,48 @@
-import { findManifestUrl } from '../src/publish';
+import { findManifestUrl, findProjectPage } from "../src/publish"
 
+describe('findProjectPageURL', () => {
+	it('should find project page URL', () => {
+		const expoPublishOutput = `
+[15:22:15] › Expo SDK: 41.0.0
+[15:22:15] › Release channel: pr-3
+[15:22:15] › Workflow: Bare
+
+[15:22:15] Building optimized bundles and generating sourcemaps...
+[15:22:17] Starting Metro Bundler
+[15:24:39] Finished building JavaScript bundle in 142513ms.
+[15:24:39]
+[15:24:39] Bundle                     Size
+┌ index.ios.js          1.63 MB
+├ index.android.js      1.64 MB
+├ index.ios.js.map      4.61 MB
+└ index.android.js.map  4.63 MB
+[15:24:39]
+[15:24:39] 💡 JavaScript bundle sizes affect startup time. Learn more: expo.fyi/javascript-bundle-sizes
+[15:24:39]
+[15:24:39] Analyzing assets
+[15:24:39] Saving assets
+[15:24:39] No assets changed, skipped.
+[15:24:39]
+Processing asset bundle patterns:
+[15:24:39] - /home/runner/work/dev-client-gh-action/dev-client-gh-action/**/*
+[15:24:39]
+[15:24:39] Uploading JavaScript bundles
+[15:24:41] Publish complete
+
+[15:24:41] 📝  Manifest: https://exp.host/@lukaszkosmaty/tabs/index.exp?release-channel=pr-3&sdkVersion=41.0.0 Learn more: expo.fyi/manifest-url
+[15:24:42] ⚙️   Project page: https://expo.dev/@markwas/here?release-channel=pr-3 Learn more: https://expo.fyi/project-page
+`;
+		const projectPageUrl = findProjectPage(expoPublishOutput);
+		expect(projectPageUrl).toBe('https://expo.dev/@markwas/here?release-channel=pr-3');
+	});
+
+	it('should throw if cannot find project page URL', () => {
+		expect(() => {
+			const expoPublishOutput = 'nothing to see here...';
+			findManifestUrl(expoPublishOutput);
+		}).toThrow();
+	});
+});
 describe('findManifestUrl', () => {
 	it('should find manifest URL', () => {
 		const expoPublishOutput = `

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -31,6 +31,7 @@ Processing asset bundle patterns:
 
 [15:24:41] 📝  Manifest: https://exp.host/@lukaszkosmaty/tabs/index.exp?release-channel=pr-3&sdkVersion=41.0.0 Learn more: expo.fyi/manifest-url
 [15:24:42] ⚙️   Project page: https://expo.dev/@markwas/here?release-channel=pr-3 Learn more: https://expo.fyi/project-page
+
 `;
 		const projectPageUrl = findProjectPage(expoPublishOutput);
 		expect(projectPageUrl).toBe('https://expo.dev/@markwas/here?release-channel=pr-3');


### PR DESCRIPTION
### Linked issue
Provide the issue(s) which this pull request relates to or fixes.
#11 

### Additional context
At the end of builds, the output includes a Project page where the QR code is available and editable, depending on what client you want it to run on (dev or expo go).
 ### Testing
You can test the action from my fork at https://github.com/marketplace/actions/expo-github-action-fork
Tested on my own private repos, and is particularly helpful when the QR codes don't work and you need a link.