### PR TITLE
fix: Expo QR code service url

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -22,7 +22,7 @@ function getExpoGoParams(manifestURL: string): ExpoGoParams {
   };
 }
 
-const generateQRCodeBaseURL = 'https://us-central1-exponentjs.cloudfunctions.net/generateQRCode';
+const generateQRCodeBaseURL = 'https://qr.expo.dev';
 
 export function createQRCodeURL(projectFlavor: ProjectFlavor, manifestURL: string, scheme: string): string {
   if (projectFlavor === ProjectFlavor.DevelopmentClient) {


### PR DESCRIPTION
### Linked issue

#13

### Additional context

It seems that the url for the service to generate QR codes has changed and the old one no longer works.