### PR TITLE
chore(action): update to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: upload-cloud
   color: gray-dark
 runs:
-  using: node12
+  using: node16
   main: build/index.js
 inputs:
   channel:


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.

Signed-off-by: Enes <ahmedenesturan@gmail.com>

### Additional context

We can work on updating the actions and environments with dependencies. 